### PR TITLE
Fix port clashing in dev

### DIFF
--- a/packages/backend/env/index.js
+++ b/packages/backend/env/index.js
@@ -10,6 +10,8 @@ if (existsSync(pathToDotEnv)) {
   const dotEnvContents = readFileSync(pathToDotEnv);
   const config = dotenv.parse(dotEnvContents);
   port = config.PORT;
+} else {
+  port = process.env.PORT;
 }
 
 module.exports = {


### PR DESCRIPTION
If the `.env` file doesn't exist in the backend, export the `process.env.PORT` variable instead instead of `undefined`.

This will then be checked in the `webpack` config for the dev server, and will throw an exception if the `port` matches.