### PR TITLE
Use createHmac instead of createHash from crypto

### DIFF
--- a/packages/backend/src/createHashFn.js
+++ b/packages/backend/src/createHashFn.js
@@ -11,6 +11,6 @@ export default ({ hashAlgo, hashKey, digestionType }: params) => (
   value: string
 ): string =>
   crypto
-    .createHash(hashAlgo, hashKey)
+    .createHmac(hashAlgo, hashKey)
     .update(value)
     .digest(digestionType);


### PR DESCRIPTION
I must've accidentally changed this in a prior PR.

`createHmac` allows you to give it a special key, while `createHash` doesn't (so the environment variable we had wasn't even working).